### PR TITLE
ID number in prepend_class_options

### DIFF
--- a/classes/controllers/forms/course_config/course_config_form.php
+++ b/classes/controllers/forms/course_config/course_config_form.php
@@ -230,7 +230,7 @@ class course_config_form extends controller_form {
             0 => get_string('none'),
             'idnumber' => get_string('idnumbercourse'),
             'shortname' => get_string('shortnamecourse'),
-            'fullname' => get_string('fullname')
+            'fullname' => get_string('fullnamecourse')
         ];
     }
 

--- a/classes/controllers/forms/course_config/course_config_form.php
+++ b/classes/controllers/forms/course_config/course_config_form.php
@@ -228,7 +228,7 @@ class course_config_form extends controller_form {
     private function get_prepend_class_options() {
         return [
             0 => get_string('none'),
-            'idnumber' => get_string('idnumber'),
+            'idnumber' => get_string('idnumbercourse'),
             'shortname' => get_string('shortnamecourse'),
             'fullname' => get_string('fullname')
         ];


### PR DESCRIPTION
In prepend_class_options the "ID number (idnumber)"  should be "Course ID number (idnumbercourse)" to avoid confusion with user idnumber.