### PR TITLE
Fixes for Moodle 4.2 to pass tests.

### DIFF
--- a/.github/workflows/moodle_ci.yml
+++ b/.github/workflows/moodle_ci.yml
@@ -31,6 +31,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: 'mariadb'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: 'pgsql'
           - php: '8.0'
             moodle-branch: 'MOODLE_402_STABLE'
             database: 'mariadb'

--- a/.github/workflows/moodle_ci.yml
+++ b/.github/workflows/moodle_ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     services:
       postgres:
@@ -15,7 +15,6 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
-
       mariadb:
         image: mariadb:10
         env:
@@ -23,6 +22,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
           MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
           MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
@@ -32,17 +32,17 @@ jobs:
       matrix:
         include:
           - php: '7.4'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_401_STABLE'
+            moodle-branch: 'MOODLE_311_STABLE'
             database: 'pgsql'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_311_STABLE'
+            database: 'mariadb'
           - php: '8.0'
             moodle-branch: 'MOODLE_402_STABLE'
-            database: 'mariadb'
+            database: 'pgsql'
           - php: '8.1'
             moodle-branch: 'master'
-            database: 'pgsql'
+            database: 'mariadb'
 
     steps:
       - name: Check out repository code
@@ -56,18 +56,16 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
           ini-values: max_input_vars=5000
-          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
-          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
+          # none to use phpdbg fallback. Specify pcov (Moodle 3.10 and up) or xdebug to use them instead.
           coverage: none
 
       - name: Initialise moodle-plugin-ci
         run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
           echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
-
       - name: Install moodle-plugin-ci
         run: |
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
@@ -91,11 +89,11 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci phpcs --max-warnings 0
+        run: moodle-plugin-ci codechecker --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci phpdoc --max-warnings 0
+        run: moodle-plugin-ci phpdoc
 
       - name: Validating
         if: ${{ always() }}

--- a/.github/workflows/moodle_ci.yml
+++ b/.github/workflows/moodle_ci.yml
@@ -1,9 +1,32 @@
-name: Moodle plugin CI
+name: Moodle Plugin CI
+
 on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
     strategy:
       fail-fast: false
       matrix:
@@ -15,104 +38,79 @@ jobs:
             moodle-branch: 'master'
             database: 'pgsql'
 
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: 'postgres'
-          POSTGRES_HOST_AUTH_METHOD: 'trust'
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
-        ports:
-          - 5432:5432
-
-      mariadb:
-        image: mariadb:10
-        env:
-          MYSQL_USER: 'root'
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Check out repository code
+        uses: actions/checkout@v3
         with:
           path: plugin
 
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: zip, gd, mbstring, pgsql, mysqli
+          extensions: ${{ matrix.extensions }}
           ini-values: max_input_vars=5000
+          # If you are not using code coverage, keep "none". Otherwise, use "pcov" (Moodle 3.10 and up) or "xdebug".
+          # If you try to use code coverage with "none", it will fallback to phpdbg (which has known problems).
           coverage: none
 
-      - name: Deploy moodle-plugin-ci
+      - name: Initialise moodle-plugin-ci
         run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
-          # Add dirs to $PATH
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
-          # PHPUnit depends on en_AU.UTF-8 locale
           sudo locale-gen en_AU.UTF-8
-      - name: Install Moodle
-        # Need explicit IP to stop mysql client fail on attempt to use unix socket.
-        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: ${{ matrix.database }}
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
-          IGNORE_PATHS: 'tool/printable/classes/bfpdf.php'
 
-      - name: phplint
+      - name: PHP Lint
         if: ${{ always() }}
         run: moodle-plugin-ci phplint
 
-      - name: phpcpd
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
         if: ${{ always() }}
-        run: moodle-plugin-ci phpcpd || true
+        run: moodle-plugin-ci phpcpd
 
-      - name: phpmd
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
         if: ${{ always() }}
         run: moodle-plugin-ci phpmd
 
-      - name: codechecker
+      - name: Moodle Code Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci codechecker
+        run: moodle-plugin-ci phpcs --max-warnings 0
 
       - name: Moodle PHPDoc Checker
         if: ${{ always() }}
-        run: moodle-plugin-ci phpdoc
+        run: moodle-plugin-ci phpdoc --max-warnings 0
 
-      - name: validate
+      - name: Validating
         if: ${{ always() }}
         run: moodle-plugin-ci validate
 
-      - name: savepoints
+      - name: Check upgrade savepoints
         if: ${{ always() }}
         run: moodle-plugin-ci savepoints
 
-      - name: mustache
+      - name: Mustache Lint
         if: ${{ always() }}
         run: moodle-plugin-ci mustache
 
-      - name: grunt
+      - name: Grunt
         if: ${{ always() }}
-        run: moodle-plugin-ci grunt
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
 
-      - name: phpunit
+      - name: PHPUnit tests
         if: ${{ always() }}
-        run: moodle-plugin-ci phpunit
+        run: moodle-plugin-ci phpunit --fail-on-warning
 
-      - name: behat
+      - name: Behat features
         if: ${{ always() }}
         run: moodle-plugin-ci behat --profile chrome

--- a/.github/workflows/moodle_ci.yml
+++ b/.github/workflows/moodle_ci.yml
@@ -1,0 +1,118 @@
+name: Moodle plugin CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.0'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: 'mariadb'
+          - php: '8.1'
+            moodle-branch: 'master'
+            database: 'pgsql'
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+        ports:
+          - 5432:5432
+
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: zip, gd, mbstring, pgsql, mysqli
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Deploy moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          # Add dirs to $PATH
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          # PHPUnit depends on en_AU.UTF-8 locale
+          sudo locale-gen en_AU.UTF-8
+      - name: Install Moodle
+        # Need explicit IP to stop mysql client fail on attempt to use unix socket.
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          IGNORE_PATHS: 'tool/printable/classes/bfpdf.php'
+
+      - name: phplint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: phpcpd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: phpmd
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: codechecker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: validate
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: mustache
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt
+
+      - name: phpunit
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit
+
+      - name: behat
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/classes/messenger/message/data_mapper/maps_course_data.php
+++ b/classes/messenger/message/data_mapper/maps_course_data.php
@@ -79,12 +79,12 @@ trait maps_course_data {
         global $DB;
 
         $sql = "SELECT ue.timestart
-                FROM mdl_course AS c
-                JOIN mdl_enrol AS en ON en.courseid = c.id
-                JOIN mdl_user_enrolments AS ue ON ue.enrolid = en.id
-                JOIN mdl_user AS u ON ue.userid = u.id
-                JOIN mdl_context AS ct ON c.id = ct.instanceid
-                JOIN mdl_role_assignments AS ra ON ra.contextid = ct.id
+                FROM {course} AS c
+                JOIN {enrol} AS en ON en.courseid = c.id
+                JOIN {user_enrolments} AS ue ON ue.enrolid = en.id
+                JOIN {user} AS u ON ue.userid = u.id
+                JOIN {context} AS ct ON c.id = ct.instanceid
+                JOIN {role_assignments} AS ra ON ra.contextid = ct.id
                 WHERE u.id = ?
                 AND c.id = ?
                 AND ra.roleid = 5
@@ -107,12 +107,12 @@ trait maps_course_data {
         global $DB;
 
         $sql = "SELECT ue.timeend
-                FROM mdl_course AS c
-                JOIN mdl_enrol AS en ON en.courseid = c.id
-                JOIN mdl_user_enrolments AS ue ON ue.enrolid = en.id
-                JOIN mdl_user AS u ON ue.userid = u.id
-                JOIN mdl_context AS ct ON c.id = ct.instanceid
-                JOIN mdl_role_assignments AS ra ON ra.contextid = ct.id
+                FROM {course} AS c
+                JOIN {enrol} AS en ON en.courseid = c.id
+                JOIN {user_enrolments} AS ue ON ue.enrolid = en.id
+                JOIN {user} AS u ON ue.userid = u.id
+                JOIN {context} AS ct ON c.id = ct.instanceid
+                JOIN {role_assignments} AS ra ON ra.contextid = ct.id
                 WHERE u.id = ?
                 AND c.id = ?
                 AND ra.roleid = 5

--- a/classes/messenger/messenger.php
+++ b/classes/messenger/messenger.php
@@ -81,6 +81,7 @@ class messenger implements messenger_interface {
      * @throws critical_exception
      */
     public static function compose($user, $course, $formdata, $draftmessage = null, $sendastasks = true) {
+//die("user = " . serialize($user));
         // Validate basic message form data.
         self::validate_message_form_data($formdata, 'compose');
 
@@ -614,7 +615,7 @@ class messenger implements messenger_interface {
         );
 
         $this->message->set("body", $body);
-                             
+
         // Instantiate recipient_send_factory.
         $recipientsendfactory = recipient_send_factory::make(
             $this->message,

--- a/classes/messenger/messenger.php
+++ b/classes/messenger/messenger.php
@@ -81,7 +81,6 @@ class messenger implements messenger_interface {
      * @throws critical_exception
      */
     public static function compose($user, $course, $formdata, $draftmessage = null, $sendastasks = true) {
-//die("user = " . serialize($user));
         // Validate basic message form data.
         self::validate_message_form_data($formdata, 'compose');
 

--- a/classes/notifier/models/reminder/course_non_participation_model.php
+++ b/classes/notifier/models/reminder/course_non_participation_model.php
@@ -49,7 +49,7 @@ class course_non_participation_model extends reminder_notification_model impleme
 
         global $DB;
 
-        $results = $DB->get_records_sql('SELECT u.id
+        $results = $DB->get_records_sql("SELECT u.id
             FROM {user} u
             INNER JOIN {user_enrolments} ue ON ue.userid = u.id
             INNER JOIN {enrol} e ON e.id = ue.enrolid
@@ -57,9 +57,9 @@ class course_non_participation_model extends reminder_notification_model impleme
             INNER JOIN {role_assignments} ra ON ra.userid = u.id
             INNER JOIN {context} ctx ON ctx.id = ra.contextid AND ctx.instanceid = c.id
             WHERE u.id NOT IN (SELECT la.userid FROM {user_lastaccess} la WHERE la.courseid = c.id AND la.timeaccess > ?)
-            AND ra.roleid IN (SELECT value FROM {config} WHERE name = "gradebookroles")
+            AND ra.roleid IN (SELECT CAST(value AS INT) FROM {config} WHERE name = 'gradebookroles')
             AND c.id = ?
-            GROUP BY u.id', [$this->condition->get_offset_timestamp_from_now('before'), $this->get_course_id()]);
+            GROUP BY u.id", [$this->condition->get_offset_timestamp_from_now('before'), $this->get_course_id()]);
 
         return array_keys($results);
     }

--- a/classes/persistents/message_recipient.php
+++ b/classes/persistents/message_recipient.php
@@ -98,9 +98,9 @@ class message_recipient extends \block_quickmail\persistents\persistent {
         // First check the user exists.
 
         $usertestrecord = array_values($DB->get_records_sql(
-            'SELECT deleted
-                FROM mdl_user
-                WHERE id = ?',
+            "SELECT deleted
+                FROM {user}
+                WHERE id = ?",
             array($userid)
         ));
 

--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -126,7 +126,7 @@ class block_quickmail_plugin {
         // If we're broadcasting, only allow admins.
         if ($sendtype == 'broadcast') {
             // Make sure we have the correct context (system).
-            if (get_class($context) !== 'context_system') {
+            if (get_class($context) !== 'core\context\system' && get_class($context) !== 'context_system') {
                 return false;
             }
 
@@ -135,7 +135,7 @@ class block_quickmail_plugin {
 
         // Otherwise, we're composing.
         // Make sure we have the correct context (course).
-        if (get_class($context) !== 'context_course') {
+        if (get_class($context) !== 'core\context\course' && get_class($context) !== 'context_course') {
             return false;
         }
 

--- a/tests/unit/alternate_manager_test.php
+++ b/tests/unit/alternate_manager_test.php
@@ -29,7 +29,7 @@ use block_quickmail\services\alternate_manager;
 use block_quickmail\persistents\alternate_email;
 use block_quickmail\exceptions\validation_exception;
 
-class block_quickmail_alternate_manager_testcase extends advanced_testcase {
+class alternate_manager_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/alternate_persistent_test.php
+++ b/tests/unit/alternate_persistent_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\persistents\alternate_email;
 
-class block_quickmail_alternate_persistent_testcase extends advanced_testcase {
+class alternate_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;
@@ -102,14 +102,14 @@ class block_quickmail_alternate_persistent_testcase extends advanced_testcase {
 
         $allowedroles = $alternate->get_allowed_roles();
 
-        $this->assertInternalType('array', $allowedroles);
+        $this->assertIsArray($allowedroles);
         $this->assertCount(3, $allowedroles);
 
         $alternate = $this->create_alternate($userteacher, $course, 'course', 'email@example.com', true, '');
 
         $allowedroles = $alternate->get_allowed_roles();
 
-        $this->assertInternalType('array', $allowedroles);
+        $this->assertIsArray($allowedroles);
         $this->assertCount(0, $allowedroles);
     }
 
@@ -157,7 +157,7 @@ class block_quickmail_alternate_persistent_testcase extends advanced_testcase {
 
         $alternates = alternate_email::get_flat_array_for_course_user($course->id, $userteacher);
 
-        $this->assertInternalType('array', $alternates);
+        $this->assertIsArray($alternates);
         $this->assertCount(6, $alternates);
     }
 
@@ -216,7 +216,7 @@ class block_quickmail_alternate_persistent_testcase extends advanced_testcase {
         $alternates = alternate_email::get_flat_array_for_course_user($course->id, $teacher1, false);
 
         // Teacher 1 should have access to only 2.
-        $this->assertInternalType('array', $alternates);
+        $this->assertIsArray($alternates);
         $this->assertCount(2, $alternates);
     }
 

--- a/tests/unit/body_substitution_code_parser_test.php
+++ b/tests/unit/body_substitution_code_parser_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\messenger\message\body_substitution_code_parser;
 
-class block_quickmail_body_substitution_code_parser_testcase extends advanced_testcase {
+class body_substitution_code_parser_test extends advanced_testcase {
 
     use has_general_helpers;
 
@@ -36,7 +36,7 @@ class block_quickmail_body_substitution_code_parser_testcase extends advanced_te
 
         $codes = body_substitution_code_parser::get_codes($message);
 
-        $this->assertInternalType('array', $codes);
+        $this->assertIsArray($codes);
         $this->assertCount(0, $codes);
     }
 
@@ -46,7 +46,7 @@ class block_quickmail_body_substitution_code_parser_testcase extends advanced_te
 
         $codes = body_substitution_code_parser::get_codes($message);
 
-        $this->assertInternalType('array', $codes);
+        $this->assertIsArray($codes);
         $this->assertCount(6, $codes);
         $this->assertContains('hey', $codes);
         $this->assertContains('some', $codes);

--- a/tests/unit/cache_test.php
+++ b/tests/unit/cache_test.php
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_cache_testcase extends advanced_testcase {
+class cache_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/configuration_test.php
+++ b/tests/unit/configuration_test.php
@@ -66,9 +66,9 @@ class configuration_test extends advanced_testcase {
 
         $this->assertIsArray($setting);
         $this->assertCount(3, $setting);
-        $this->assertContains(3, $setting);
-        $this->assertContains(4, $setting);
-        $this->assertContains(5, $setting);
+        $this->assertContains('3', $setting);
+        $this->assertContains('4', $setting);
+        $this->assertContains('5', $setting);
 
         // Get default course setting - 3,4,5.
         $course = $this->getDataGenerator()->create_course();
@@ -77,9 +77,9 @@ class configuration_test extends advanced_testcase {
 
         $this->assertIsArray($setting);
         $this->assertCount(3, $setting);
-        $this->assertContains(3, $setting);
-        $this->assertContains(4, $setting);
-        $this->assertContains(5, $setting);
+        $this->assertContains('3', $setting);
+        $this->assertContains('4', $setting);
+        $this->assertContains('5', $setting);
 
         // Update the course's settings.
         $newparams = [
@@ -103,8 +103,8 @@ class configuration_test extends advanced_testcase {
 
         $this->assertIsArray($setting);
         $this->assertCount(2, $setting);
-        $this->assertContains(1, $setting);
-        $this->assertContains(2, $setting);
+        $this->assertContains('1', $setting);
+        $this->assertContains('2', $setting);
     }
 
     public function test_reports_course_ferpa_strictness() {

--- a/tests/unit/configuration_test.php
+++ b/tests/unit/configuration_test.php
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_configuration_testcase extends advanced_testcase {
+class configuration_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;
@@ -35,7 +35,7 @@ class block_quickmail_configuration_testcase extends advanced_testcase {
 
         $config = block_quickmail_config::block();
 
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
     }
 
     public function test_fetches_course_config_as_array() {
@@ -45,7 +45,7 @@ class block_quickmail_configuration_testcase extends advanced_testcase {
 
         $config = block_quickmail_config::course($course);
 
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
     }
 
     public function test_fetches_course_id_config_as_array() {
@@ -55,7 +55,7 @@ class block_quickmail_configuration_testcase extends advanced_testcase {
 
         $config = block_quickmail_config::course($course->id);
 
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
     }
 
     public function test_fetches_role_selection_setting_as_array() {
@@ -64,7 +64,7 @@ class block_quickmail_configuration_testcase extends advanced_testcase {
         // Get default block setting - 3,4,5.
         $setting = block_quickmail_config::get_role_selection_array();
 
-        $this->assertInternalType('array', $setting);
+        $this->assertIsArray($setting);
         $this->assertCount(3, $setting);
         $this->assertContains(3, $setting);
         $this->assertContains(4, $setting);
@@ -75,7 +75,7 @@ class block_quickmail_configuration_testcase extends advanced_testcase {
 
         $setting = block_quickmail_config::get_role_selection_array($course);
 
-        $this->assertInternalType('array', $setting);
+        $this->assertIsArray($setting);
         $this->assertCount(3, $setting);
         $this->assertContains(3, $setting);
         $this->assertContains(4, $setting);
@@ -101,7 +101,7 @@ class block_quickmail_configuration_testcase extends advanced_testcase {
 
         $setting = block_quickmail_config::get_role_selection_array($course);
 
-        $this->assertInternalType('array', $setting);
+        $this->assertIsArray($setting);
         $this->assertCount(2, $setting);
         $this->assertContains(1, $setting);
         $this->assertContains(2, $setting);

--- a/tests/unit/course_recipient_send_factory_test.php
+++ b/tests/unit/course_recipient_send_factory_test.php
@@ -29,7 +29,7 @@ use block_quickmail\messenger\factories\course_recipient_send\recipient_send_fac
 use block_quickmail\messenger\factories\course_recipient_send\email_recipient_send_factory;
 use block_quickmail\messenger\factories\course_recipient_send\message_recipient_send_factory;
 
-class block_quickmail_course_recipient_send_factory_testcase extends advanced_testcase {
+class course_recipient_send_factory_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -92,9 +92,9 @@ class block_quickmail_course_recipient_send_factory_testcase extends advanced_te
 
         $factory = recipient_send_factory::make($message, $recipient, null, null);
 
-        $this->assertInternalType('object', $factory->message_params->userto);
+        $this->assertIsObject($factory->message_params->userto);
         $this->assertEquals($firststudent->id, $factory->message_params->userto->id);
-        $this->assertInternalType('object', $factory->message_params->userfrom);
+        $this->assertIsObject($factory->message_params->userfrom);
         $this->assertEquals($userteacher->id, $factory->message_params->userfrom->id);
     }
 

--- a/tests/unit/course_repo_test.php
+++ b/tests/unit/course_repo_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\repos\course_repo;
 
-class block_quickmail_course_repo_testcase extends advanced_testcase {
+class course_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/draft_repo_test.php
+++ b/tests/unit/draft_repo_test.php
@@ -29,7 +29,7 @@ use block_quickmail\repos\draft_repo;
 use block_quickmail\persistents\message;
 use block_quickmail\repos\pagination\paginated;
 
-class block_quickmail_draft_repo_testcase extends advanced_testcase {
+class draft_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/edit_event_notification_form_validator_test.php
+++ b/tests/unit/edit_event_notification_form_validator_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\validators\edit_notification_form_validator;
 
-class block_quickmail_edit_event_notification_form_validator_testcase extends advanced_testcase {
+class edit_event_notification_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/edit_notification_form_validator_test.php
+++ b/tests/unit/edit_notification_form_validator_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\validators\edit_notification_form_validator;
 
-class block_quickmail_edit_notification_form_validator_testcase extends advanced_testcase {
+class edit_notification_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/edit_reminder_notification_form_validator_test.php
+++ b/tests/unit/edit_reminder_notification_form_validator_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\validators\edit_notification_form_validator;
 
-class block_quickmail_edit_reminder_notification_form_validator_testcase extends advanced_testcase {
+class edit_reminder_notification_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/emailer_test.php
+++ b/tests/unit/emailer_test.php
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_emailer_testcase extends advanced_testcase {
+class emailer_test extends advanced_testcase {
 
     use has_general_helpers,
         sends_emails;

--- a/tests/unit/event_notification_course_entered_model_test.php
+++ b/tests/unit/event_notification_course_entered_model_test.php
@@ -29,7 +29,7 @@ use block_quickmail\persistents\notification;
 use block_quickmail\notifier\models\notification_model_helper;
 use block_quickmail\notifier\models\event\course_entered_model;
 
-class block_quickmail_event_notification_course_entered_model_testcase extends advanced_testcase {
+class event_notification_course_entered_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -63,7 +63,7 @@ class block_quickmail_event_notification_course_entered_model_testcase extends a
 
         // Test gets available condition keys.
         $keys = notification_model_helper::get_condition_keys_for_model('event', 'course_entered');
-        $this->assertInternalType('array', $keys);
+        $this->assertIsArray($keys);
         $this->assertCount(0, $keys);
 
         // Test gets required condition keys.

--- a/tests/unit/event_notification_handler_test.php
+++ b/tests/unit/event_notification_handler_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\notifier\event_notification_handler;
 
-class block_quickmail_event_notification_handler_testcase extends advanced_testcase {
+class event_notification_handler_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/event_notification_persistent_test.php
+++ b/tests/unit/event_notification_persistent_test.php
@@ -29,7 +29,7 @@ use block_quickmail\persistents\event_notification;
 use block_quickmail\persistents\notification;
 use block_quickmail\notifier\models\event_notification_model;
 
-class block_quickmail_event_notification_persistent_testcase extends advanced_testcase {
+class event_notification_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/formats_message_recipient_compose_message_body_test.php
+++ b/tests/unit/formats_message_recipient_compose_message_body_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\messenger\message\message_body_constructor;
 
-class block_quickmail_parses_compose_message_body_testcase extends advanced_testcase {
+class formats_message_recipient_compose_message_body_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/group_repo_test.php
+++ b/tests/unit/group_repo_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\repos\group_repo;
 
-class block_quickmail_group_repo_testcase extends advanced_testcase {
+class group_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;
@@ -48,12 +48,12 @@ class block_quickmail_group_repo_testcase extends advanced_testcase {
 
         $firstgroup = current($groups);
 
-        $this->assertInternalType('array', $groups);
+        $this->assertIsArray($groups);
         $this->assertCount(3, $groups);
         $this->assertArrayHasKey($redgroup->id, $groups);
         $this->assertArrayHasKey($yellowgroup->id, $groups);
         $this->assertArrayHasKey($bluegroup->id, $groups);
-        $this->assertInternalType('object', $firstgroup);
+        $this->assertIsObject($firstgroup);
         $this->assertObjectHasAttribute('id', $firstgroup);
         $this->assertObjectHasAttribute('name', $firstgroup);
 
@@ -62,7 +62,7 @@ class block_quickmail_group_repo_testcase extends advanced_testcase {
         // Should have access to only two groups.
         $groups = group_repo::get_course_user_selectable_groups($course, $student);
 
-        $this->assertInternalType('array', $groups);
+        $this->assertIsArray($groups);
         $this->assertCount(2, $groups);
         $this->assertArrayHasKey($redgroup->id, $groups);
         $this->assertArrayHasKey($yellowgroup->id, $groups);
@@ -83,7 +83,7 @@ class block_quickmail_group_repo_testcase extends advanced_testcase {
 
         $groups = group_repo::get_course_user_groups($course, $editingteacher, $coursecontext);
 
-        $this->assertInternalType('array', $groups);
+        $this->assertIsArray($groups);
         $this->assertCount(0, $groups);
 
         $student = $enrolledusers['student'][0];
@@ -93,12 +93,12 @@ class block_quickmail_group_repo_testcase extends advanced_testcase {
 
         $firstgroup = current($groups);
 
-        $this->assertInternalType('array', $groups);
+        $this->assertIsArray($groups);
         $this->assertCount(2, $groups);
         $this->assertArrayHasKey($redgroup->id, $groups);
         $this->assertArrayHasKey($yellowgroup->id, $groups);
         $this->assertArrayNotHasKey($bluegroup->id, $groups);
-        $this->assertInternalType('object', $firstgroup);
+        $this->assertIsObject($firstgroup);
         $this->assertObjectHasAttribute('id', $firstgroup);
         $this->assertObjectHasAttribute('name', $firstgroup);
 
@@ -109,7 +109,7 @@ class block_quickmail_group_repo_testcase extends advanced_testcase {
 
         $firstgroup = current($groups);
 
-        $this->assertInternalType('array', $groups);
+        $this->assertIsArray($groups);
         $this->assertCount(0, $groups);
     }
 

--- a/tests/unit/message_form_validator_test.php
+++ b/tests/unit/message_form_validator_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\validators\message_form_validator;
 
-class block_quickmail_message_form_validator_testcase extends advanced_testcase {
+class message_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/message_persistent_test.php
+++ b/tests/unit/message_persistent_test.php
@@ -30,7 +30,7 @@ use block_quickmail\persistents\message_draft_recipient;
 use block_quickmail\persistents\message_recipient;
 use block_quickmail\persistents\message_additional_email;
 
-class block_quickmail_message_persistent_testcase extends advanced_testcase {
+class message_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -221,7 +221,7 @@ class block_quickmail_message_persistent_testcase extends advanced_testcase {
 
         $messagerecipientusers = $message->get_message_recipient_users('all', 'id,email');
 
-        $this->assertInternalType('array', $messagerecipientusers);
+        $this->assertIsArray($messagerecipientusers);
         $this->assertCount(3, $messagerecipientusers);
         $this->assertEquals($userone->id, $messagerecipientusers[$userone->id]->id);
         $this->assertEquals($userone->email, $messagerecipientusers[$userone->id]->email);

--- a/tests/unit/messenger_compose_test.php
+++ b/tests/unit/messenger_compose_test.php
@@ -57,6 +57,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(4, $this->email_sink_email_count($sink));
@@ -89,6 +92,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         // Should have been sent to 4 users + 1 mentor.
@@ -117,6 +123,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(0, $this->email_sink_email_count($sink));
@@ -140,6 +149,9 @@ class messenger_compose_test extends advanced_testcase {
         $composeformdata = $this->get_compose_message_form_submission($recipients, 'message', []);
 
         // Send a moodle message from the teacher to the students now (not as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(4, $this->message_sink_message_count($sink));
@@ -165,6 +177,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(1, $this->email_sink_email_count($sink));
@@ -193,6 +208,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Schedule an email from the teacher to the students (as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata);
 
         \phpunit_util::run_all_adhoc_tasks();
@@ -221,6 +239,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(7, $this->email_sink_email_count($sink));
@@ -255,6 +276,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(5, $this->email_sink_email_count($sink));
@@ -295,6 +319,9 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertTrue($this->email_in_sink_body_contains($sink, 1, 'This is one fine body.'));

--- a/tests/unit/messenger_compose_test.php
+++ b/tests/unit/messenger_compose_test.php
@@ -30,7 +30,7 @@ use block_quickmail\persistents\message;
 use block_quickmail\persistents\signature;
 use block_quickmail\exceptions\validation_exception;
 
-class block_quickmail_messenger_compose_testcase extends advanced_testcase {
+class messenger_compose_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/messenger_drafting_test.php
+++ b/tests/unit/messenger_drafting_test.php
@@ -58,6 +58,9 @@ class messenger_drafting_test extends advanced_testcase {
         ]);
 
         // Save this email message as a draft.
+        // Set the teacher as global $USER as this will be used when saving drafts.
+        global $USER;
+        $USER = $userteacher;
         $message = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
         $messagerecipients = $message->get_message_recipients();
@@ -87,6 +90,9 @@ class messenger_drafting_test extends advanced_testcase {
         ]);
 
         // Save this email message as a draft.
+        // Set the teacher as global $USER as this will be used when saving drafts.
+        global $USER;
+        $USER = $userteacher;
         $draftmessage = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
         $this->expectException(validation_exception::class);
@@ -114,6 +120,9 @@ class messenger_drafting_test extends advanced_testcase {
         ]);
 
         // Save this email message as a draft.
+        // Set the teacher as global $USER as this will be used when saving drafts.
+        global $USER;
+        $USER = $userteacher;
         $draftmessage = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
         // Now attempt to duplicate this draft.

--- a/tests/unit/messenger_drafting_test.php
+++ b/tests/unit/messenger_drafting_test.php
@@ -30,7 +30,7 @@ use block_quickmail\persistents\message;
 use block_quickmail\persistents\signature;
 use block_quickmail\exceptions\validation_exception;
 
-class block_quickmail_messenger_drafting_testcase extends advanced_testcase {
+class messenger_drafting_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/notification_condition_summary_test.php
+++ b/tests/unit/notification_condition_summary_test.php
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\notifier\notification_condition_summary;
-class block_quickmail_notification_condition_summary_testcase extends advanced_testcase {
+class notification_condition_summary_test extends advanced_testcase {
     use has_general_helpers;
     public function test_gets_summary_for_reminder_course_non_participation_notification() {
         $params = [
@@ -34,7 +34,7 @@ class block_quickmail_notification_condition_summary_testcase extends advanced_t
         ];
 
         $summary = notification_condition_summary::get_model_condition_summary('reminder', 'course_non_participation', $params);
-        $this->assertInternalType('string', $summary);
+        $this->assertIsString($summary);
         $this->assertEquals('All who have not accessed the course in 3 days', $summary);
 
         $params = [
@@ -43,7 +43,7 @@ class block_quickmail_notification_condition_summary_testcase extends advanced_t
         ];
 
         $summary = notification_condition_summary::get_model_condition_summary('reminder', 'course_non_participation', $params);
-        $this->assertInternalType('string', $summary);
+        $this->assertIsString($summary);
         $this->assertEquals('All who have not accessed the course in 1 week', $summary);
     }
 

--- a/tests/unit/notification_condition_test.php
+++ b/tests/unit/notification_condition_test.php
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\notifier\notification_condition;
-class block_quickmail_notification_condition_testcase extends advanced_testcase {
+class notification_condition_test extends advanced_testcase {
     use has_general_helpers;
 
     public function test_formats_condition_for_storage() {

--- a/tests/unit/notification_model_helper_test.php
+++ b/tests/unit/notification_model_helper_test.php
@@ -27,21 +27,21 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\notifier\models\notification_model_helper;
 
-class block_quickmail_notification_model_helper_testcase extends advanced_testcase {
+class notification_model_helper_test extends advanced_testcase {
 
     use has_general_helpers;
 
     public function test_gets_available_reminder_model_keys_by_type() {
         $types = notification_model_helper::get_available_model_keys_by_type('reminder');
 
-        $this->assertInternalType('array', $types);
+        $this->assertIsArray($types);
         $this->assertCount(count(block_quickmail_plugin::get_model_notification_types('reminder')), $types);
     }
 
     public function test_gets_available_event_model_keys_by_type() {
         $types = notification_model_helper::get_available_model_keys_by_type('event');
 
-        $this->assertInternalType('array', $types);
+        $this->assertIsArray($types);
         $this->assertCount(count(block_quickmail_plugin::get_model_notification_types('event')), $types);
     }
 

--- a/tests/unit/notification_persistent_test.php
+++ b/tests/unit/notification_persistent_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\persistents\notification;
 
-class block_quickmail_notification_persistent_testcase extends advanced_testcase {
+class notification_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/notification_repo_test.php
+++ b/tests/unit/notification_repo_test.php
@@ -29,7 +29,7 @@ use block_quickmail\repos\notification_repo;
 use block_quickmail\persistents\notification;
 use block_quickmail\repos\pagination\paginated;
 
-class block_quickmail_notification_repo_testcase extends advanced_testcase {
+class notification_repo_test extends advanced_testcase {
     use has_general_helpers,
         sets_up_courses,
         sets_up_notifications;

--- a/tests/unit/notification_schedule_summary_test.php
+++ b/tests/unit/notification_schedule_summary_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\notifier\notification_schedule_summary;
 
-class block_quickmail_notification_schedule_summary_testcase extends advanced_testcase {
+class notification_schedule_summary_test extends advanced_testcase {
 
     use has_general_helpers;
 
@@ -36,7 +36,7 @@ class block_quickmail_notification_schedule_summary_testcase extends advanced_te
 
         $summary = notification_schedule_summary::get_from_params($params);
 
-        $this->assertInternalType('string', $summary);
+        $this->assertIsString($summary);
         $this->assertEquals('', $summary);
 
         $begin = $this->get_timestamp_for_date('jun 26 2018 08:30:00');
@@ -51,7 +51,7 @@ class block_quickmail_notification_schedule_summary_testcase extends advanced_te
 
         $summary = notification_schedule_summary::get_from_params($params);
 
-        $this->assertInternalType('string', $summary);
+        $this->assertIsString($summary);
         $this->assertEquals('Every 3 Days, Beginning Jun 26 2018, 12:30am, Ending Nov 30 2018, 12:30am', $summary);
 
         $begin = $this->get_timestamp_for_date('jun 26 2018 08:30:00');
@@ -64,7 +64,7 @@ class block_quickmail_notification_schedule_summary_testcase extends advanced_te
 
         $summary = notification_schedule_summary::get_from_params($params);
 
-        $this->assertInternalType('string', $summary);
+        $this->assertIsString($summary);
         $this->assertEquals('Once a Week, Beginning Jun 26 2018, 12:30am', $summary);
     }
 

--- a/tests/unit/paginator_test.php
+++ b/tests/unit/paginator_test.php
@@ -28,7 +28,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\repos\pagination\paginator;
 use block_quickmail\repos\pagination\paginated;
 
-class block_quickmail_paginator_testcase extends advanced_testcase {
+class paginator_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/persistent_concerns_test.php
+++ b/tests/unit/persistent_concerns_test.php
@@ -28,7 +28,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\persistents\message;
 use block_quickmail\persistents\message_recipient;
 
-class block_quickmail_persistent_concerns_testcase extends advanced_testcase {
+class persistent_concerns_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;
@@ -119,7 +119,7 @@ class block_quickmail_persistent_concerns_testcase extends advanced_testcase {
         $deletedmessage2 = $DB->get_record('block_quickmail_messages', ['id' => $message2id]);
 
         $this->assertFalse($deletedmessage1);
-        $this->assertInternalType('object', $deletedmessage2);
+        $this->assertIsObject($deletedmessage2);
         $this->assertGreaterThan(0, $message2->get('timedeleted'));
         $this->assertTrue($message2->is_soft_deleted());
     }
@@ -137,7 +137,7 @@ class block_quickmail_persistent_concerns_testcase extends advanced_testcase {
 
         $messagecourse = $message->get_course();
 
-        $this->assertInternalType('object', $messagecourse);
+        $this->assertIsObject($messagecourse);
         $this->assertEquals($course->id, $messagecourse->id);
         $this->assertTrue($message->is_owned_by_course($course));
         $this->assertTrue($message->is_owned_by_course($course->id));
@@ -204,7 +204,7 @@ class block_quickmail_persistent_concerns_testcase extends advanced_testcase {
 
         $messageuser = $message->get_user();
 
-        $this->assertInternalType('object', $messageuser);
+        $this->assertIsObject($messageuser);
         $this->assertEquals($user->id, $messageuser->id);
         $this->assertTrue($message->is_owned_by_user($user));
         $this->assertTrue($message->is_owned_by_user($user->id));

--- a/tests/unit/queue_scheduled_notifications_task_test.php
+++ b/tests/unit/queue_scheduled_notifications_task_test.php
@@ -28,7 +28,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\messenger\messenger;
 use block_quickmail\tasks\queue_scheduled_notifications_task;
 
-class block_quickmail_queue_scheduled_notifications_task_testcase extends advanced_testcase {
+class queue_scheduled_notifications_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/queued_repo_test.php
+++ b/tests/unit/queued_repo_test.php
@@ -30,7 +30,7 @@ use block_quickmail\persistents\message;
 use block_quickmail\persistents\message_recipient;
 use block_quickmail\repos\pagination\paginated;
 
-class block_quickmail_queued_repo_testcase extends advanced_testcase {
+class queued_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/reminder_notification_course_grade_range_model_test.php
+++ b/tests/unit/reminder_notification_course_grade_range_model_test.php
@@ -32,7 +32,7 @@ use block_quickmail\notifier\models\reminder\course_grade_range_model;
 global $CFG;
 require_once($CFG->libdir . '/gradelib.php');
 
-class block_quickmail_reminder_notification_course_grade_range_model_testcase extends advanced_testcase {
+class reminder_notification_course_grade_range_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -66,7 +66,7 @@ class block_quickmail_reminder_notification_course_grade_range_model_testcase ex
 
         // Test gets available condition keys.
         $keys = notification_model_helper::get_condition_keys_for_model('reminder', 'course_grade_range');
-        $this->assertInternalType('array', $keys);
+        $this->assertIsArray($keys);
         $this->assertCount(2, $keys);
 
         // Test gets required condition keys.

--- a/tests/unit/reminder_notification_course_non_participation_model_test.php
+++ b/tests/unit/reminder_notification_course_non_participation_model_test.php
@@ -29,7 +29,7 @@ use block_quickmail\persistents\notification;
 use block_quickmail\notifier\models\notification_model_helper;
 use block_quickmail\notifier\models\reminder\course_non_participation_model;
 
-class block_quickmail_reminder_notification_course_non_participation_model_testcase extends advanced_testcase {
+class reminder_notification_course_non_participation_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -63,7 +63,7 @@ class block_quickmail_reminder_notification_course_non_participation_model_testc
 
         // Test gets available condition keys.
         $keys = notification_model_helper::get_condition_keys_for_model('reminder', 'course_non_participation');
-        $this->assertInternalType('array', $keys);
+        $this->assertIsArray($keys);
         $this->assertCount(2, $keys);
 
         // Test gets required condition keys.

--- a/tests/unit/reminder_notification_model_test.php
+++ b/tests/unit/reminder_notification_model_test.php
@@ -25,7 +25,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_reminder_notification_model_testcase extends advanced_testcase {
+class reminder_notification_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/reminder_notification_persistent_test.php
+++ b/tests/unit/reminder_notification_persistent_test.php
@@ -31,7 +31,7 @@ use block_quickmail\persistents\schedule;
 use block_quickmail\persistents\interfaces\notification_type_interface;
 use block_quickmail\notifier\models\reminder_notification_model;
 
-class block_quickmail_reminder_notification_persistent_testcase extends advanced_testcase {
+class reminder_notification_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/role_repo_test.php
+++ b/tests/unit/role_repo_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\repos\role_repo;
 
-class block_quickmail_role_repo_testcase extends advanced_testcase {
+class role_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;
@@ -45,9 +45,9 @@ class block_quickmail_role_repo_testcase extends advanced_testcase {
         $roles = role_repo::get_course_selectable_roles($course);
 
         $this->assertCount(3, $roles);
-        $this->assertInternalType('array', $roles);
+        $this->assertIsArray($roles);
         $this->assertArrayHasKey(3, $roles);
-        $this->assertInternalType('object', $roles[3]);
+        $this->assertIsObject($roles[3]);
         $this->assertObjectHasAttribute('id', $roles[3]);
         $this->assertObjectHasAttribute('name', $roles[3]);
         $this->assertObjectHasAttribute('shortname', $roles[3]);
@@ -71,9 +71,9 @@ class block_quickmail_role_repo_testcase extends advanced_testcase {
         $roles = role_repo::get_course_selectable_roles($course);
 
         $this->assertCount(2, $roles);
-        $this->assertInternalType('array', $roles);
+        $this->assertIsArray($roles);
         $this->assertArrayHasKey(4, $roles);
-        $this->assertInternalType('object', $roles[4]);
+        $this->assertIsObject($roles[4]);
         $this->assertObjectHasAttribute('id', $roles[4]);
         $this->assertObjectHasAttribute('name', $roles[4]);
         $this->assertObjectHasAttribute('shortname', $roles[4]);
@@ -85,9 +85,9 @@ class block_quickmail_role_repo_testcase extends advanced_testcase {
         $roleselectionarray = role_repo::get_alternate_email_role_selection_array();
 
         $this->assertCount(3, $roleselectionarray);
-        $this->assertInternalType('array', $roleselectionarray);
+        $this->assertIsArray($roleselectionarray);
         $this->assertArrayHasKey(3, $roleselectionarray);
-        $this->assertInternalType('string', $roleselectionarray[3]);
+        $this->assertIsString($roleselectionarray[3]);
 
         // Create course with enrolled users.
         list($course, $coursecontext, $users) = $this->setup_course_with_users([
@@ -126,7 +126,7 @@ class block_quickmail_role_repo_testcase extends advanced_testcase {
         // Editingteacher.
         $roleids = role_repo::get_user_roles_in_course($editingteacher->id, $course->id);
 
-        $this->assertInternalType('array', $roleids);
+        $this->assertIsArray($roleids);
         $this->assertCount(1, $roleids);
         $this->assertContains(3, $roleids);
 

--- a/tests/unit/run_schedulable_notification_adhoc_task_test.php
+++ b/tests/unit/run_schedulable_notification_adhoc_task_test.php
@@ -30,7 +30,7 @@ use block_quickmail\persistents\reminder_notification;
 use block_quickmail\tasks\run_schedulable_notification_adhoc_task;
 use core\task\manager as task_manager;
 
-class block_quickmail_run_schedulable_notification_adhoc_task_testcase extends advanced_testcase {
+class run_schedulable_notification_adhoc_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/save_draft_message_validator_test.php
+++ b/tests/unit/save_draft_message_validator_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\validators\save_draft_message_form_validator;
 
-class block_quickmail_save_draft_message_validator_testcase extends advanced_testcase {
+class save_draft_message_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/schedulable_test.php
+++ b/tests/unit/schedulable_test.php
@@ -29,7 +29,7 @@ use block_quickmail\persistents\schedule;
 use block_quickmail\persistents\reminder_notification;
 use block_quickmail\persistents\interfaces\schedulable_interface;
 
-class block_quickmail_schedulable_testcase extends advanced_testcase {
+class schedulable_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/schedule_persistent_test.php
+++ b/tests/unit/schedule_persistent_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\persistents\schedule;
 
-class block_quickmail_schedule_persistent_testcase extends advanced_testcase {
+class schedule_persistent_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/send_all_ready_messages_task_test.php
+++ b/tests/unit/send_all_ready_messages_task_test.php
@@ -28,7 +28,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\messenger\messenger;
 use block_quickmail\tasks\send_all_ready_messages_task;
 
-class block_quickmail_send_all_ready_messages_task_testcase extends advanced_testcase {
+class send_all_ready_messages_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/send_all_ready_messages_task_test.php
+++ b/tests/unit/send_all_ready_messages_task_test.php
@@ -99,6 +99,9 @@ class send_all_ready_messages_task_test extends advanced_testcase {
             ]);
 
             // Schedule an email from the teacher to the students (as queued adhoc tasks).
+            // Set the teacher as global $USER as this will be used when sending emails.
+            global $USER;
+            $USER = $userteacher;
             $message = messenger::compose($userteacher, $course, $composeformdata, null, true);
 
             $messages[] = $message;

--- a/tests/unit/send_message_adhoc_task_test.php
+++ b/tests/unit/send_message_adhoc_task_test.php
@@ -70,6 +70,9 @@ class send_message_adhoc_task_test extends advanced_testcase {
         ]);
 
         // Schedule an email from the teacher to the students (as queued adhoc tasks).
+        // Set the teacher as global $USER as this will be used when sending emails.
+        global $USER;
+        $USER = $userteacher;
         $message = messenger::compose($userteacher, $course, $composeformdata, null, true);
 
         \phpunit_util::run_all_adhoc_tasks();

--- a/tests/unit/send_message_adhoc_task_test.php
+++ b/tests/unit/send_message_adhoc_task_test.php
@@ -29,7 +29,7 @@ use block_quickmail\messenger\messenger;
 use block_quickmail\tasks\send_message_adhoc_task;
 use core\task\manager as task_manager;
 
-class block_quickmail_send_message_adhoc_task_testcase extends advanced_testcase {
+class send_message_adhoc_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/sent_repo_test.php
+++ b/tests/unit/sent_repo_test.php
@@ -29,7 +29,7 @@ use block_quickmail\repos\sent_repo;
 use block_quickmail\persistents\message;
 use block_quickmail\repos\pagination\paginated;
 
-class block_quickmail_sent_repo_testcase extends advanced_testcase {
+class sent_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/signature_appender_test.php
+++ b/tests/unit/signature_appender_test.php
@@ -47,12 +47,11 @@ class signature_appender_test extends advanced_testcase {
 
         $body = 'This is the message I hope you like it.';
 
-        $formattedbody = signature_appender::append_user_signature_to_body(
+        $formattedbody = explode('<br><br>', signature_appender::append_user_signature_to_body(
             $body,
             $userteacher->id,
             $signature->get('id')
-        );
-
+        ));
         $this->assertContains('<p>This is my signature!</p>', $formattedbody);
     }
 
@@ -70,11 +69,11 @@ class signature_appender_test extends advanced_testcase {
 
         $body = 'This is the message I hope you like it.';
 
-        $formattedbody = signature_appender::append_user_signature_to_body(
+        $formattedbody = explode('<br><br>', signature_appender::append_user_signature_to_body(
             $body,
             $userteacher->id,
             $signature->get('id')
-        );
+        ));
 
         $this->assertNotContains('<p>This is my signature!</p>', $formattedbody);
     }
@@ -93,10 +92,10 @@ class signature_appender_test extends advanced_testcase {
 
         $body = 'This is the message I hope you like it.';
 
-        $formattedbody = signature_appender::append_user_signature_to_body(
+        $formattedbody = explode('<br><br>', signature_appender::append_user_signature_to_body(
             $body,
             $userteacher->id
-        );
+        ));
 
         $this->assertNotContains('<p>This is my signature!</p>', $formattedbody);
     }

--- a/tests/unit/signature_appender_test.php
+++ b/tests/unit/signature_appender_test.php
@@ -28,7 +28,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\messenger\message\signature_appender;
 use block_quickmail\persistents\signature;
 
-class block_quickmail_signature_appender_testcase extends advanced_testcase {
+class signature_appender_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/signature_persistent_test.php
+++ b/tests/unit/signature_persistent_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\persistents\signature;
 
-class block_quickmail_signature_persistent_testcase extends advanced_testcase {
+class signature_persistent_test extends advanced_testcase {
 
     use has_general_helpers;
 
@@ -189,7 +189,7 @@ class block_quickmail_signature_persistent_testcase extends advanced_testcase {
 
         $signatures = signature::get_flat_array_for_user(1);
 
-        $this->assertInternalType('array', $signatures);
+        $this->assertIsArray($signatures);
         $this->assertCount(3, $signatures);
     }
 

--- a/tests/unit/subject_prepender_test.php
+++ b/tests/unit/subject_prepender_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\messenger\message\subject_prepender;
 
-class block_quickmail_subject_prepender_testcase extends advanced_testcase {
+class subject_prepender_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/substitution_code_test.php
+++ b/tests/unit/substitution_code_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\messenger\message\substitution_code;
 
-class block_quickmail_substitution_code_testcase extends advanced_testcase {
+class substitution_code_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/traits/submits_compose_message_form.php
+++ b/tests/unit/traits/submits_compose_message_form.php
@@ -32,7 +32,6 @@ trait submits_compose_message_form {
         $params = $this->get_compose_message_form_submission_params($overrideparams);
 
         list($includedentityids, $excludedentityids) = $this->get_recipients_array($recipients);
-
         $formdata = (object)[];
         // Default - '0' (user email), '-1' (system no reply), else alt id.
         $formdata->from_email_id = $params['from_email_id'];
@@ -85,8 +84,14 @@ trait submits_compose_message_form {
                             // Segun Babalola, 2020-10-30.
                             // Not sure how this ever worked with undescores.
                             // Recipient IDs will never have been captured.
-                            $containername = $inclusiontype . 'entityids';
-                            $containername[] = $recipienttype . '_' . $id;
+                            switch ($inclusiontype) {
+                                case "included" :
+                                    $includedentityids[]  = $recipienttype . '_' . $id;
+                                    break;
+                                case "excluded" :
+                                    $excludedentityids[]  = $recipienttype . '_' . $id;
+                                    break;
+                            }
                         }
                     }
                 }

--- a/tests/unit/user_repo_test.php
+++ b/tests/unit/user_repo_test.php
@@ -27,7 +27,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
 use block_quickmail\repos\user_repo;
 
-class block_quickmail_user_repo_testcase extends advanced_testcase {
+class user_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -56,11 +56,11 @@ class block_quickmail_user_repo_testcase extends advanced_testcase {
 
         $firstuser = current($users);
 
-        $this->assertInternalType('array', $users);
+        $this->assertIsArray($users);
         $this->assertCount(44, $users);
         $this->assertArrayHasKey($editingteacher->id, $users);
         $this->assertArrayHasKey($student->id, $users);
-        $this->assertInternalType('object', $firstuser);
+        $this->assertIsObject($firstuser);
         $this->assertObjectHasAttribute('id', $firstuser);
         $this->assertObjectHasAttribute('firstname', $firstuser);
         $this->assertObjectHasAttribute('lastname', $firstuser);
@@ -68,7 +68,7 @@ class block_quickmail_user_repo_testcase extends advanced_testcase {
         // Should have limited access.
         $users = user_repo::get_course_user_selectable_users($course, $student, $coursecontext);
 
-        $this->assertInternalType('array', $users);
+        $this->assertIsArray($users);
         $this->assertCount(22, $users);
     }
 


### PR DESCRIPTION
- replaced deprecated assertInternalType() functions
- renamed test classes
- fixed trait submits_compose_message_form
- fixed missing iterate object in signature_appender_test.php
- using correct table relations in SQL code, 
- updated SQL to make sure to return INT
- asserting strings not integers in configuration_test.php
- setting $USER to $userteacher in tests

