### PR TITLE
Update messenger.php call to undefined function

### DIFF
--- a/classes/messenger/messenger.php
+++ b/classes/messenger/messenger.php
@@ -600,6 +600,8 @@ class messenger implements messenger_interface {
      * @return bool
      */
     public function send_to_recipient($recipient) {
+        global $CFG;
+        require_once($CFG->libdir . '/filelib.php');
         $coursecontext = \context_course::instance($this->message->get("course_id"));
         $body = file_rewrite_pluginfile_urls(
             $this->message->get("body"),


### PR DESCRIPTION
Adhoc task send_message_adhoc_task fails due to undefined function in block_quickmail\messenger\file_rewrite_pluginfile_urls() see below. Missing include libdir --> filelib.php.

Execute adhoc task: block_quickmail\tasks\send_message_adhoc_task
Adhoc task id: 4826102
Adhoc task custom data: {"message_id":"1450"}
... started 22:15:58. Current memory use 16.0 MB.
... used 5 dbqueries
... used 0.0045909881591797 seconds
Adhoc task failed: block_quickmail\tasks\send_message_adhoc_task,Call to undefined function block_quickmail\messenger\file_rewrite_pluginfile_urls()
Backtrace:
* line 585 of /blocks/quickmail/classes/messenger/messenger.php: call to block_quickmail\messenger\messenger->send_to_recipient()
* line 790 of /blocks/quickmail/classes/persistents/message.php: call to block_quickmail\messenger\messenger->send()
* line 45 of /blocks/quickmail/classes/tasks/send_message_adhoc_task.php: call to block_quickmail\persistents\message->send()
* line 508 of /lib/classes/cron.php: call to block_quickmail\tasks\send_message_adhoc_task->execute()
* line 348 of /lib/classes/cron.php: call to core\cron::run_inner_adhoc_task()
* line 368 of /lib/classes/cron.php: call to core\cron::run_adhoc_task()
* line 154 of /admin/cli/adhoc_task.php: call to core\cron::run_failed_adhoc_tasks()
