### PR TITLE
Update subject_prepender.php to correctly display course title

### DIFF
--- a/classes/messenger/message/subject_prepender.php
+++ b/classes/messenger/message/subject_prepender.php
@@ -85,7 +85,7 @@ class subject_prepender {
                 break;
 
             case 'fullname':
-                return $this->get_prepended_with($course->fullname);
+                return $this->get_prepended_with(format_string($course->fullname));
                 break;
 
             default:


### PR DESCRIPTION
When the course title contains html tags, the title prepender displays them, instead of formatting the string.