### PR TITLE
Fix for Message Duplication Error #74

### DIFF
--- a/classes/filemanager/message_file_handler.php
+++ b/classes/filemanager/message_file_handler.php
@@ -76,8 +76,8 @@ class message_file_handler {
      * @return void
      */
     public static function duplicate_files($original, $new, $filearea) {
-        $originalhandler = new self($original);
-        $course = $original->get_course();
+        $originalhandler = new self($new);
+        $course = $new->get_course();
         $context = context_course::instance($course->id);
 
         $files = $originalhandler->fetch_uploaded_file_data($filearea);


### PR DESCRIPTION
https://github.com/lsuonline/lsuce-block_quickmail/issues/74

Changing the call from $original to $new fixes the duplication error