### PR TITLE
Fixed issue #71

### DIFF
--- a/tests/unit/messenger_compose_test.php
+++ b/tests/unit/messenger_compose_test.php
@@ -57,6 +57,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(4, $this->email_sink_email_count($sink));
@@ -89,6 +90,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         // Should have been sent to 4 users + 1 mentor.
@@ -117,6 +119,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(0, $this->email_sink_email_count($sink));
@@ -140,6 +143,7 @@ class messenger_compose_test extends advanced_testcase {
         $composeformdata = $this->get_compose_message_form_submission($recipients, 'message', []);
 
         // Send a moodle message from the teacher to the students now (not as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(4, $this->message_sink_message_count($sink));
@@ -165,6 +169,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(1, $this->email_sink_email_count($sink));
@@ -193,6 +198,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Schedule an email from the teacher to the students (as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata);
 
         \phpunit_util::run_all_adhoc_tasks();
@@ -221,6 +227,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(7, $this->email_sink_email_count($sink));
@@ -255,6 +262,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertEquals(5, $this->email_sink_email_count($sink));
@@ -295,6 +303,7 @@ class messenger_compose_test extends advanced_testcase {
         ]);
 
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
+        $this->setUser($userteacher);
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
         $this->assertTrue($this->email_in_sink_body_contains($sink, 1, 'This is one fine body.'));

--- a/tests/unit/messenger_drafting_test.php
+++ b/tests/unit/messenger_drafting_test.php
@@ -58,6 +58,7 @@ class messenger_drafting_test extends advanced_testcase {
         ]);
 
         // Save this email message as a draft.
+        $this->setUser($userteacher);
         $message = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
         $messagerecipients = $message->get_message_recipients();
@@ -87,6 +88,7 @@ class messenger_drafting_test extends advanced_testcase {
         ]);
 
         // Save this email message as a draft.
+        $this->setUser($userteacher);
         $draftmessage = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
         $this->expectException(validation_exception::class);
@@ -114,6 +116,7 @@ class messenger_drafting_test extends advanced_testcase {
         ]);
 
         // Save this email message as a draft.
+        $this->setUser($userteacher);
         $draftmessage = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
         // Now attempt to duplicate this draft.

--- a/tests/unit/send_all_ready_messages_task_test.php
+++ b/tests/unit/send_all_ready_messages_task_test.php
@@ -28,7 +28,7 @@ require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 use block_quickmail\messenger\messenger;
 use block_quickmail\tasks\send_all_ready_messages_task;
 
-class block_quickmail_send_all_ready_messages_task_testcase extends advanced_testcase {
+class send_all_ready_messages_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -99,6 +99,7 @@ class block_quickmail_send_all_ready_messages_task_testcase extends advanced_tes
             ]);
 
             // Schedule an email from the teacher to the students (as queued adhoc tasks).
+            $this->setUser($userteacher);
             $message = messenger::compose($userteacher, $course, $composeformdata, null, true);
 
             $messages[] = $message;

--- a/tests/unit/send_message_adhoc_task_test.php
+++ b/tests/unit/send_message_adhoc_task_test.php
@@ -29,7 +29,7 @@ use block_quickmail\messenger\messenger;
 use block_quickmail\tasks\send_message_adhoc_task;
 use core\task\manager as task_manager;
 
-class block_quickmail_send_message_adhoc_task_testcase extends advanced_testcase {
+class send_message_adhoc_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,
@@ -70,6 +70,7 @@ class block_quickmail_send_message_adhoc_task_testcase extends advanced_testcase
         ]);
 
         // Schedule an email from the teacher to the students (as queued adhoc tasks).
+        $this->setUser($userteacher);
         $message = messenger::compose($userteacher, $course, $composeformdata, null, true);
 
         \phpunit_util::run_all_adhoc_tasks();

--- a/tests/unit/traits/submits_compose_message_form.php
+++ b/tests/unit/traits/submits_compose_message_form.php
@@ -86,7 +86,7 @@ trait submits_compose_message_form {
                             // Not sure how this ever worked with undescores.
                             // Recipient IDs will never have been captured.
                             $containername = $inclusiontype . 'entityids';
-                            $containername[] = $recipienttype . '_' . $id;
+                            $$containername[] = $recipienttype . '_' . $id;
                         }
                     }
                 }


### PR DESCRIPTION
setting userteacher as user in tests before messenger::compose or messenger::save_compose_draft, 
restoring doubledollar in line 89 of submits_compose_message_form.php.
This will fix issue #71.