### PR TITLE
"Deprecated: Creation of dynamic property" warnings with PHP 8.2

### DIFF
--- a/block_quickmail.php
+++ b/block_quickmail.php
@@ -28,8 +28,8 @@ class block_quickmail extends block_list {
     public $course;
     public $user;
     public $content;
-    public $systemcontext;
-    public $coursecontext;
+    public $system_context;
+    public $course_context;
 
     public function init() {
         $this->title = $this->get_title();

--- a/classes/emailer.php
+++ b/classes/emailer.php
@@ -30,13 +30,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class block_quickmail_emailer {
 
-    public $fromuser;
+    public $from_user;
     public $subject;
     public $body;
-    public $toemail;
-    public $touser;
-    public $replytoemail;
-    public $replytoname;
+    public $to_email;
+    public $to_user;
+    public $reply_to_email;
+    public $reply_to_name;
     public $wordwrapwidth;
 
     /**

--- a/classes/filemanager/attachment_appender.php
+++ b/classes/filemanager/attachment_appender.php
@@ -38,8 +38,8 @@ class attachment_appender {
 
     public $message;
     public $body;
-    public $coursecontext;
-    public $messageattachments;
+    public $course_context;
+    public $message_attachments;
 
     public function __construct(message $message, $body) {
         $this->message = $message;

--- a/classes/filemanager/message_file_handler.php
+++ b/classes/filemanager/message_file_handler.php
@@ -38,8 +38,8 @@ class message_file_handler {
     public $message;
     public $course;
     public $context;
-    public $filestorage;
-    public $uploadedfiles;
+    public $file_storage;
+    public $uploaded_files;
 
     public function __construct(message $message) {
         $this->message = $message;

--- a/classes/messenger/factories/course_recipient_send/recipient_send_factory.php
+++ b/classes/messenger/factories/course_recipient_send/recipient_send_factory.php
@@ -44,10 +44,10 @@ abstract class recipient_send_factory {
     public $message;
     public $recipient;
     public $course;
-    public $messageparams;
-    public $alternateemail;
-    public $allprofilefields;
-    public $selectedprofilefields;
+    public $message_params;
+    public $alternate_email;
+    public $all_profile_fields;
+    public $selected_profile_fields;
 
     public function __construct($message, $recipient, $allprofilefields, $selectedprofilefields) {
         $this->message = $message;

--- a/classes/messenger/message/message_body_constructor.php
+++ b/classes/messenger/message/message_body_constructor.php
@@ -35,7 +35,7 @@ class message_body_constructor {
     public $message;
     public $user;
     public $course;
-    public $allowedsubstitutioncodeclasses;
+    public $allowed_substitution_code_classes;
 
     public function __construct(message $message, $user, $course = null) {
         $this->message = $message;

--- a/classes/messenger/message/signature_appender.php
+++ b/classes/messenger/message/signature_appender.php
@@ -30,8 +30,8 @@ use block_quickmail\persistents\signature;
 class signature_appender {
 
     public $body;
-    public $userid;
-    public $signatureid;
+    public $user_id;
+    public $signature_id;
 
     /**
      * Construct the message signature appender

--- a/classes/messenger/messenger.php
+++ b/classes/messenger/messenger.php
@@ -52,8 +52,8 @@ use html_writer;
 class messenger implements messenger_interface {
 
     public $message;
-    public $allprofilefields;
-    public $selectedprofilefields;
+    public $all_profile_fields;
+    public $selected_profile_fields;
 
     public function __construct(message $message) {
         $this->message = $message;

--- a/classes/notifier/models/notification_model.php
+++ b/classes/notifier/models/notification_model.php
@@ -34,7 +34,7 @@ abstract class notification_model implements notification_model_interface {
 
     public static $objecttype = '';
     public static $conditionkeys = [];
-    public $notificationtypeinterface;
+    public $notification_type_interface;
     public $notification;
     public $condition;
 

--- a/classes/notifier/notification_condition_summary.php
+++ b/classes/notifier/notification_condition_summary.php
@@ -30,7 +30,7 @@ use block_quickmail_string;
 
 class notification_condition_summary {
 
-    public $langstringkey;
+    public $lang_string_key;
     public $params;
 
     public function __construct($langstringkey, $params = []) {

--- a/classes/repos/pagination/paginated.php
+++ b/classes/repos/pagination/paginated.php
@@ -36,19 +36,19 @@ use block_quickmail\repos\pagination\paginator;
 class paginated {
 
     public $paginator;
-    public $pagecount;
+    public $page_count;
     public $offset;
-    public $perpage;
-    public $currentpage;
-    public $nextpage;
-    public $previouspage;
-    public $totalcount;
-    public $emptyuri;
-    public $uriforpage;
-    public $firstpageuri;
-    public $lastpageuri;
-    public $nextpageuri;
-    public $previouspageuri;
+    public $per_page;
+    public $current_page;
+    public $next_page;
+    public $previous_page;
+    public $total_count;
+    public $empty_uri;
+    public $uri_for_page;
+    public $first_page_uri;
+    public $last_page_uri;
+    public $next_page_uri;
+    public $previous_page_uri;
 
     public function __construct(paginator $paginator) {
         $this->paginator = $paginator;

--- a/classes/repos/pagination/paginator.php
+++ b/classes/repos/pagination/paginator.php
@@ -29,11 +29,11 @@ use block_quickmail\repos\pagination\paginated;
 
 class paginator {
 
-    public $totalcount;
+    public $total_count;
     public $page;
-    public $perpage;
-    public $pageuri;
-    public $totalpages;
+    public $per_page;
+    public $page_uri;
+    public $total_pages;
     public $offset;
 
     public function __construct($totalcount, $page = 1, $perpage = 10, $pageuri = '') {

--- a/classes/repos/repo.php
+++ b/classes/repos/repo.php
@@ -34,7 +34,7 @@ abstract class repo {
     public $dir;
     public $paginate;
     public $page;
-    public $perpage;
+    public $per_page;
     public $uri;
     public $result;
 

--- a/classes/requests/transformers/transformer.php
+++ b/classes/requests/transformers/transformer.php
@@ -27,8 +27,8 @@ defined('MOODLE_INTERNAL') || die();
 
 class transformer {
 
-    public $formdata;
-    public $transformeddata;
+    public $form_data;
+    public $transformed_data;
 
     /**
      * Construct the transformer

--- a/classes/validators/message_form_validator.php
+++ b/classes/validators/message_form_validator.php
@@ -34,7 +34,7 @@ use block_quickmail\exceptions\body_parser_exception;
 
 class message_form_validator extends validator {
 
-    public $transformeddata;
+    public $transformed_data;
 
     /**
      * Defines this specific validator's validation rules

--- a/classes/validators/save_draft_message_form_validator.php
+++ b/classes/validators/save_draft_message_form_validator.php
@@ -35,7 +35,7 @@ use block_quickmail\exceptions\body_parser_exception;
 
 class save_draft_message_form_validator extends validator {
 
-    public $transformeddata;
+    public $transformed_data;
 
     /**
      * Defines this specific validator's validation rules

--- a/classes/validators/validator.php
+++ b/classes/validators/validator.php
@@ -29,8 +29,8 @@ use block_quickmail_config;
 
 abstract class validator {
 
-    public $formdata;
-    public $extraparams;
+    public $form_data;
+    public $extra_params;
     public $errors;
     public $course;
 

--- a/tests/unit/messenger_compose_test.php
+++ b/tests/unit/messenger_compose_test.php
@@ -56,6 +56,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
             'body' => 'This is one fine body.',
         ]);
 
+        $this->setUser($userteacher);
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
@@ -88,6 +89,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
             'mentor_copy' => 1,
         ]);
 
+        $this->setUser($userteacher);
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
@@ -139,6 +141,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
         // Get a compose form submission.
         $composeformdata = $this->get_compose_message_form_submission($recipients, 'message', []);
 
+        $this->setUser($userteacher);
         // Send a moodle message from the teacher to the students now (not as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
@@ -164,6 +167,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
             'body' => 'This is one fine body.',
         ]);
 
+        $this->setUser($userteacher);
         // Send an email from the teacher to the students as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
@@ -192,6 +196,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
             'to_send_at' => $nextweek
         ]);
 
+        $this->setUser($userteacher);
         // Schedule an email from the teacher to the students (as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata);
 
@@ -220,6 +225,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
             'additional_emails' => 'additional@one.com,additional@two.com,additional@three.com'
         ]);
 
+        $this->setUser($userteacher);
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
@@ -254,6 +260,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
             'receipt' => '1'
         ]);
 
+        $this->setUser($userteacher);
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 
@@ -294,6 +301,7 @@ class block_quickmail_messenger_compose_testcase extends advanced_testcase {
             'signature_id' => $signature->get('id')
         ]);
 
+        $this->setUser($userteacher);
         // Send an email from the teacher to the students now (not as queued adhoc tasks).
         messenger::compose($userteacher, $course, $composeformdata, null, false);
 

--- a/tests/unit/messenger_drafting_test.php
+++ b/tests/unit/messenger_drafting_test.php
@@ -57,6 +57,7 @@ class block_quickmail_messenger_drafting_testcase extends advanced_testcase {
             'body' => 'This is one fine body.',
         ]);
 
+        $this->setUser($userteacher);
         // Save this email message as a draft.
         $message = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
@@ -86,6 +87,7 @@ class block_quickmail_messenger_drafting_testcase extends advanced_testcase {
             'body' => 'This is one fine body.',
         ]);
 
+        $this->setUser($userteacher);
         // Save this email message as a draft.
         $draftmessage = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 
@@ -113,6 +115,7 @@ class block_quickmail_messenger_drafting_testcase extends advanced_testcase {
             'body' => 'This is one fine body.',
         ]);
 
+        $this->setUser($userteacher);
         // Save this email message as a draft.
         $draftmessage = messenger::save_compose_draft($userteacher, $course, $composeformdata);
 

--- a/tests/unit/send_all_ready_messages_task_test.php
+++ b/tests/unit/send_all_ready_messages_task_test.php
@@ -98,6 +98,7 @@ class block_quickmail_send_all_ready_messages_task_testcase extends advanced_tes
                 'to_send_at' => $timetosend
             ]);
 
+            $this->setUser($userteacher);
             // Schedule an email from the teacher to the students (as queued adhoc tasks).
             $message = messenger::compose($userteacher, $course, $composeformdata, null, true);
 

--- a/tests/unit/send_message_adhoc_task_test.php
+++ b/tests/unit/send_message_adhoc_task_test.php
@@ -69,6 +69,7 @@ class block_quickmail_send_message_adhoc_task_testcase extends advanced_testcase
             'to_send_at' => $sendtime
         ]);
 
+        $this->setUser($userteacher);
         // Schedule an email from the teacher to the students (as queued adhoc tasks).
         $message = messenger::compose($userteacher, $course, $composeformdata, null, true);
 

--- a/tests/unit/traits/has_general_helpers.php
+++ b/tests/unit/traits/has_general_helpers.php
@@ -84,19 +84,9 @@ trait has_general_helpers {
         return $params;
     }
 
-    public function update_system_config_value($configname, $newvalue) {
-        global $DB;
-
-        if ($record = $DB->get_record('config', ['name' => $configname])) {
-            $record->value = $newvalue;
-
-            $DB->update_record('config', $record);
-        } else {
-            $DB->insert_record('config', (object)[
-                'name' => $configname,
-                'value' => $newvalue,
-            ]);
-        }
+    public function update_system_config_value($configname, $newvalue): void
+    {
+        set_config($configname, $newvalue);
     }
 
     public function override_params($values, $overrides) {

--- a/tests/unit/traits/submits_compose_message_form.php
+++ b/tests/unit/traits/submits_compose_message_form.php
@@ -82,11 +82,7 @@ trait submits_compose_message_form {
                 foreach (['role', 'group', 'user'] as $recipienttype) {
                     if (array_key_exists($recipienttype, $recipients[$inclusiontype])) {
                         foreach ($recipients[$inclusiontype][$recipienttype] as $id) {
-                            // Segun Babalola, 2020-10-30.
-                            // Not sure how this ever worked with undescores.
-                            // Recipient IDs will never have been captured.
-                            $containername = $inclusiontype . 'entityids';
-                            $containername[] = $recipienttype . '_' . $id;
+                            ${$inclusiontype . 'entityids'}[] = $recipienttype . '_' . $id;
                         }
                     }
                 }


### PR DESCRIPTION
Fixed some of the warnings and issues poping up when installing the plugin and while running test cases on PHP 8.2. All the test case pass now for PHP 8.2