### PR TITLE
Remove error_log line that creates noice in the php error log.

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -196,7 +196,6 @@ class block_quickmail_plugin {
         }
 
         // Check whether context locking is enabled.
-        error_log("What is context locking: ". $CFG->contextlocking);
         $pageaccess = explode(",", get_config('moodle', 'block_quickmail_frozen_readonly_pages'));
 
         if (in_array($page, $pageaccess)) {


### PR DESCRIPTION
We have seen a lot of log lines like:
[Tue Oct 15 10:46:30.098192 2024] [proxy_fcgi:error] [pid 907922:tid 139823085172288] [remote XX.XX.XX.XX.YYYYY] AH01071: Got error 'PHP message: What is context locking: 1', referer: https://our-moodle/my/courses.php

This is because of a error_log() that is writing the state of $CFG->contextlocking. I guess this is a left over from some debugging and therefore think it can be removed.
