### PR TITLE
Increase $plugin->requires to Moodle 4.0

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version = 2024101701;
-$plugin->requires = 2016052300;
+$plugin->requires = 2022041900;
 $plugin->release = "v4.2.2";
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'block_quickmail';


### PR DESCRIPTION
In 0c9c9da, @ChaoticDalo changed the code to use the `MESSAGE_DEFAULT_ENABLED` constant.

The constant `MESSAGE_DEFAULT_ENABLED` was first released in Moodle 4.0, so we must increase the `$plugin->requires` to `2022041900`.