### PR TITLE
fix for students being able to send mails

### DIFF
--- a/classes/plugin.php
+++ b/classes/plugin.php
@@ -139,8 +139,8 @@ class block_quickmail_plugin {
             return false;
         }
 
-        if (self::check_frozen_context($user, $context, $page)) {
-            return true;
+        if (!self::check_frozen_context($user, $context, $page)) {
+            return false;
         }
 
         if (self::user_has_capability('cansend', $user, $context)) {


### PR DESCRIPTION
This fixes the issue of students being able to see the block and send mails without having the capability.