### PR TITLE
[fix] Fixing #106.

### DIFF
--- a/classes/persistents/message.php
+++ b/classes/persistents/message.php
@@ -183,7 +183,7 @@ class message extends \block_quickmail\persistents\persistent {
         global $DB;
 
         $messageid = $this->get('id');
-        $cuser = $this->get('user_id');
+        $cuser = $DB->get_record('user', ['id' => $this->get('user_id')]);
         $course = $DB->get_record('course', ['id' => $this->get('course_id')]);
         $coursemsg = new message($messageid);
 


### PR DESCRIPTION
Fix #106 
In the method ```[\block_quickmail\persistents\message::populate_recip_course_msg]```, instead of passing an (user) object to the ```[\block_quickmail\repos\user_repo::get_unique_course_user_ids_from_selected_entities]``` method, it was passing the [user id] only, making the ```[\block_quickmail\repos\user_repo::get_unique_course_user_ids_from_selected_entities]``` method use a string as if it were an object. This PR fix this.

Note2:
- I applied this hotfix to my production environment and it's been working as intended for 2 days already.
- I did not write any tests int this PR because my prod env was chaos and I did not (and still don't) have time to study the tests of the package in order to do it.