### PR TITLE
removed static declaration as already declared in parent

### DIFF
--- a/block_quickmail.php
+++ b/block_quickmail.php
@@ -30,7 +30,6 @@ class block_quickmail extends block_list {
     public $content;
     public $systemcontext;
     public $coursecontext;
-    public string $title;
 
     public function init() {
         $this->title = $this->get_title();


### PR DESCRIPTION
Sorry, me again.
Just found out that declaring variale types is not allowed in block_quickmail.php for inheritance reasons (it seems that when the parent isn't declaring types for a variable you shouln't try to assing one) - so removed again.
This will fix #122.
Sorry for the fuzz.
