### PR TITLE
Align unit test class names with files, namespace and make final

### DIFF
--- a/tests/unit/alternate_manager_test.php
+++ b/tests/unit/alternate_manager_test.php
@@ -21,15 +21,21 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\services\alternate_manager;
-use block_quickmail\persistents\alternate_email;
+use advanced_testcase;
 use block_quickmail\exceptions\validation_exception;
+use block_quickmail\persistents\alternate_email;
+use block_quickmail\services\alternate_manager;
+use has_general_helpers;
+use sends_emails;
+use sets_up_courses;
 
-class block_quickmail_alternate_manager_testcase extends advanced_testcase {
+final class alternate_manager_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/alternate_persistent_test.php
+++ b/tests/unit/alternate_persistent_test.php
@@ -21,13 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\persistents\alternate_email;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_alternate_persistent_testcase extends advanced_testcase {
+final class alternate_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/body_substitution_code_parser_test.php
+++ b/tests/unit/body_substitution_code_parser_test.php
@@ -21,13 +21,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\messenger\message\body_substitution_code_parser;
+use has_general_helpers;
 
-class block_quickmail_body_substitution_code_parser_testcase extends advanced_testcase {
+final class body_substitution_code_parser_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/cache_test.php
+++ b/tests/unit/cache_test.php
@@ -21,11 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
+use advanced_testcase;
+use block_quickmail_cache;
+use core_cache\cache;
+use has_general_helpers;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_cache_testcase extends advanced_testcase {
+final class cache_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/configuration_test.php
+++ b/tests/unit/configuration_test.php
@@ -21,11 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
+use advanced_testcase;
+use block_quickmail_config;
+use has_general_helpers;
+use sets_up_courses;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_configuration_testcase extends advanced_testcase {
+final class configuration_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/course_recipient_send_factory_test.php
+++ b/tests/unit/course_recipient_send_factory_test.php
@@ -21,15 +21,21 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\messenger\factories\course_recipient_send\recipient_send_factory;
+use advanced_testcase;
 use block_quickmail\messenger\factories\course_recipient_send\email_recipient_send_factory;
 use block_quickmail\messenger\factories\course_recipient_send\message_recipient_send_factory;
+use block_quickmail\messenger\factories\course_recipient_send\recipient_send_factory;
+use creates_message_records;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_course_recipient_send_factory_testcase extends advanced_testcase {
+final class course_recipient_send_factory_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/course_repo_test.php
+++ b/tests/unit/course_repo_test.php
@@ -21,13 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\repos\course_repo;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_course_repo_testcase extends advanced_testcase {
+final class course_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/draft_repo_test.php
+++ b/tests/unit/draft_repo_test.php
@@ -21,15 +21,20 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\repos\draft_repo;
+use advanced_testcase;
 use block_quickmail\persistents\message;
+use block_quickmail\repos\draft_repo;
 use block_quickmail\repos\pagination\paginated;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_draft_repo_testcase extends advanced_testcase {
+final class draft_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/edit_event_notification_form_validator_test.php
+++ b/tests/unit/edit_event_notification_form_validator_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\validators\edit_notification_form_validator;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_edit_event_notification_form_validator_testcase extends advanced_testcase {
+final class edit_event_notification_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/edit_notification_form_validator_test.php
+++ b/tests/unit/edit_notification_form_validator_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\validators\edit_notification_form_validator;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_edit_notification_form_validator_testcase extends advanced_testcase {
+final class edit_notification_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/edit_reminder_notification_form_validator_test.php
+++ b/tests/unit/edit_reminder_notification_form_validator_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\validators\edit_notification_form_validator;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_edit_reminder_notification_form_validator_testcase extends advanced_testcase {
+final class edit_reminder_notification_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/emailer_test.php
+++ b/tests/unit/emailer_test.php
@@ -21,11 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
+use advanced_testcase;
+use block_quickmail_emailer;
+use has_general_helpers;
+use sends_emails;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_emailer_testcase extends advanced_testcase {
+final class emailer_test extends advanced_testcase {
 
     use has_general_helpers,
         sends_emails;

--- a/tests/unit/event_notification_course_entered_model_test.php
+++ b/tests/unit/event_notification_course_entered_model_test.php
@@ -21,15 +21,22 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\persistents\notification;
-use block_quickmail\notifier\models\notification_model_helper;
+use advanced_testcase;
 use block_quickmail\notifier\models\event\course_entered_model;
+use block_quickmail\notifier\models\notification_model_helper;
+use block_quickmail\persistents\notification;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notification_models;
+use sets_up_notifications;
 
-class block_quickmail_event_notification_course_entered_model_testcase extends advanced_testcase {
+final class event_notification_course_entered_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/event_notification_handler_test.php
+++ b/tests/unit/event_notification_handler_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\notifier\event_notification_handler;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_event_notification_handler_testcase extends advanced_testcase {
+final class event_notification_handler_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/event_notification_persistent_test.php
+++ b/tests/unit/event_notification_persistent_test.php
@@ -21,15 +21,21 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
+use block_quickmail\notifier\models\event_notification_model;
 use block_quickmail\persistents\event_notification;
 use block_quickmail\persistents\notification;
-use block_quickmail\notifier\models\event_notification_model;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_event_notification_persistent_testcase extends advanced_testcase {
+final class event_notification_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/formats_message_recipient_compose_message_body_test.php
+++ b/tests/unit/formats_message_recipient_compose_message_body_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\messenger\message\message_body_constructor;
+use creates_message_records;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_parses_compose_message_body_testcase extends advanced_testcase {
+final class formats_message_recipient_compose_message_body_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/group_repo_test.php
+++ b/tests/unit/group_repo_test.php
@@ -21,13 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\repos\group_repo;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_group_repo_testcase extends advanced_testcase {
+final class group_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/message_form_validator_test.php
+++ b/tests/unit/message_form_validator_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\validators\message_form_validator;
+use has_general_helpers;
+use sets_up_courses;
+use submits_compose_message_form;
 
-class block_quickmail_message_form_validator_testcase extends advanced_testcase {
+final class message_form_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/message_persistent_test.php
+++ b/tests/unit/message_persistent_test.php
@@ -21,16 +21,23 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\persistents\message;
+use block_quickmail\persistents\message_additional_email;
 use block_quickmail\persistents\message_draft_recipient;
 use block_quickmail\persistents\message_recipient;
-use block_quickmail\persistents\message_additional_email;
+use block_quickmail_string;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_message_persistent_testcase extends advanced_testcase {
+final class message_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/messenger_compose_test.php
+++ b/tests/unit/messenger_compose_test.php
@@ -21,16 +21,25 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\messenger\messenger;
-use block_quickmail\persistents\message;
-use block_quickmail\persistents\signature;
+use advanced_testcase;
+use assigns_mentors;
 use block_quickmail\exceptions\validation_exception;
+use block_quickmail\messenger\messenger;
+use block_quickmail\persistents\signature;
+use block_quickmail_string;
+use has_general_helpers;
+use sends_emails;
+use sends_messages;
+use sets_up_courses;
+use submits_compose_message_form;
 
-class block_quickmail_messenger_compose_testcase extends advanced_testcase {
+final class messenger_compose_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/messenger_drafting_test.php
+++ b/tests/unit/messenger_drafting_test.php
@@ -21,16 +21,24 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
+use assigns_mentors;
+use block_quickmail\exceptions\validation_exception;
 use block_quickmail\messenger\messenger;
 use block_quickmail\persistents\message;
-use block_quickmail\persistents\signature;
-use block_quickmail\exceptions\validation_exception;
+use has_general_helpers;
+use sends_emails;
+use sends_messages;
+use sets_up_courses;
+use submits_compose_message_form;
 
-class block_quickmail_messenger_drafting_testcase extends advanced_testcase {
+final class messenger_drafting_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/notification_condition_summary_test.php
+++ b/tests/unit/notification_condition_summary_test.php
@@ -21,11 +21,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
+
+use advanced_testcase;
 use block_quickmail\notifier\notification_condition_summary;
-class block_quickmail_notification_condition_summary_testcase extends advanced_testcase {
+use has_general_helpers;
+
+final class notification_condition_summary_test extends advanced_testcase {
     use has_general_helpers;
     public function test_gets_summary_for_reminder_course_non_participation_notification() {
         $params = [

--- a/tests/unit/notification_condition_test.php
+++ b/tests/unit/notification_condition_test.php
@@ -21,11 +21,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
+
+use advanced_testcase;
 use block_quickmail\notifier\notification_condition;
-class block_quickmail_notification_condition_testcase extends advanced_testcase {
+use has_general_helpers;
+
+final class notification_condition_test extends advanced_testcase {
     use has_general_helpers;
 
     public function test_formats_condition_for_storage() {

--- a/tests/unit/notification_model_helper_test.php
+++ b/tests/unit/notification_model_helper_test.php
@@ -21,13 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\notifier\models\notification_model_helper;
+use block_quickmail_plugin;
+use has_general_helpers;
 
-class block_quickmail_notification_model_helper_testcase extends advanced_testcase {
+final class notification_model_helper_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/notification_persistent_test.php
+++ b/tests/unit/notification_persistent_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\persistents\notification;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_notification_persistent_testcase extends advanced_testcase {
+final class notification_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/notification_repo_test.php
+++ b/tests/unit/notification_repo_test.php
@@ -21,15 +21,21 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\repos\notification_repo;
+use advanced_testcase;
 use block_quickmail\persistents\notification;
+use block_quickmail\repos\notification_repo;
 use block_quickmail\repos\pagination\paginated;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_notification_repo_testcase extends advanced_testcase {
+final class notification_repo_test extends advanced_testcase {
     use has_general_helpers,
         sets_up_courses,
         sets_up_notifications;

--- a/tests/unit/notification_schedule_summary_test.php
+++ b/tests/unit/notification_schedule_summary_test.php
@@ -21,13 +21,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\notifier\notification_schedule_summary;
+use has_general_helpers;
 
-class block_quickmail_notification_schedule_summary_testcase extends advanced_testcase {
+final class notification_schedule_summary_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/paginator_test.php
+++ b/tests/unit/paginator_test.php
@@ -21,14 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\repos\pagination\paginator;
+use advanced_testcase;
 use block_quickmail\repos\pagination\paginated;
+use block_quickmail\repos\pagination\paginator;
+use has_general_helpers;
 
-class block_quickmail_paginator_testcase extends advanced_testcase {
+final class paginator_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/persistent_concerns_test.php
+++ b/tests/unit/persistent_concerns_test.php
@@ -21,14 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\persistents\message;
 use block_quickmail\persistents\message_recipient;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_persistent_concerns_testcase extends advanced_testcase {
+final class persistent_concerns_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/queue_scheduled_notifications_task_test.php
+++ b/tests/unit/queue_scheduled_notifications_task_test.php
@@ -21,14 +21,21 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\messenger\messenger;
+use advanced_testcase;
 use block_quickmail\tasks\queue_scheduled_notifications_task;
+use has_general_helpers;
+use sends_emails;
+use sends_messages;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_queue_scheduled_notifications_task_testcase extends advanced_testcase {
+final class queue_scheduled_notifications_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/queued_repo_test.php
+++ b/tests/unit/queued_repo_test.php
@@ -21,16 +21,21 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\repos\queued_repo;
+use advanced_testcase;
 use block_quickmail\persistents\message;
 use block_quickmail\persistents\message_recipient;
 use block_quickmail\repos\pagination\paginated;
+use block_quickmail\repos\queued_repo;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_queued_repo_testcase extends advanced_testcase {
+final class queued_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/reminder_notification_course_grade_range_model_test.php
+++ b/tests/unit/reminder_notification_course_grade_range_model_test.php
@@ -21,18 +21,25 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\persistents\notification;
+use advanced_testcase;
 use block_quickmail\notifier\models\notification_model_helper;
 use block_quickmail\notifier\models\reminder\course_grade_range_model;
+use block_quickmail\persistents\notification;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notification_models;
+use sets_up_notifications;
 
 global $CFG;
 require_once($CFG->libdir . '/gradelib.php');
 
-class block_quickmail_reminder_notification_course_grade_range_model_testcase extends advanced_testcase {
+final class reminder_notification_course_grade_range_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/reminder_notification_course_non_participation_model_test.php
+++ b/tests/unit/reminder_notification_course_non_participation_model_test.php
@@ -21,15 +21,22 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\persistents\notification;
+use advanced_testcase;
 use block_quickmail\notifier\models\notification_model_helper;
 use block_quickmail\notifier\models\reminder\course_non_participation_model;
+use block_quickmail\persistents\notification;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notification_models;
+use sets_up_notifications;
 
-class block_quickmail_reminder_notification_course_non_participation_model_testcase extends advanced_testcase {
+final class reminder_notification_course_non_participation_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/reminder_notification_model_test.php
+++ b/tests/unit/reminder_notification_model_test.php
@@ -21,11 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
+use advanced_testcase;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-class block_quickmail_reminder_notification_model_testcase extends advanced_testcase {
+final class reminder_notification_model_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/reminder_notification_persistent_test.php
+++ b/tests/unit/reminder_notification_persistent_test.php
@@ -21,17 +21,23 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\persistents\reminder_notification;
-use block_quickmail\persistents\notification;
-use block_quickmail\persistents\schedule;
-use block_quickmail\persistents\interfaces\notification_type_interface;
+use advanced_testcase;
 use block_quickmail\notifier\models\reminder_notification_model;
+use block_quickmail\persistents\interfaces\notification_type_interface;
+use block_quickmail\persistents\notification;
+use block_quickmail\persistents\reminder_notification;
+use block_quickmail\persistents\schedule;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_reminder_notification_persistent_testcase extends advanced_testcase {
+final class reminder_notification_persistent_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/role_repo_test.php
+++ b/tests/unit/role_repo_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\repos\role_repo;
+use block_quickmail_config;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_role_repo_testcase extends advanced_testcase {
+final class role_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/run_schedulable_notification_adhoc_task_test.php
+++ b/tests/unit/run_schedulable_notification_adhoc_task_test.php
@@ -21,16 +21,23 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\messenger\messenger;
+use advanced_testcase;
 use block_quickmail\persistents\reminder_notification;
 use block_quickmail\tasks\run_schedulable_notification_adhoc_task;
 use core\task\manager as task_manager;
+use has_general_helpers;
+use sends_emails;
+use sends_messages;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_run_schedulable_notification_adhoc_task_testcase extends advanced_testcase {
+final class run_schedulable_notification_adhoc_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/save_draft_message_validator_test.php
+++ b/tests/unit/save_draft_message_validator_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\validators\save_draft_message_form_validator;
+use has_general_helpers;
+use sets_up_courses;
+use submits_compose_message_form;
 
-class block_quickmail_save_draft_message_validator_testcase extends advanced_testcase {
+final class save_draft_message_validator_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/schedulable_test.php
+++ b/tests/unit/schedulable_test.php
@@ -21,15 +21,20 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\persistents\schedule;
+use advanced_testcase;
 use block_quickmail\persistents\reminder_notification;
-use block_quickmail\persistents\interfaces\schedulable_interface;
+use block_quickmail\persistents\schedule;
+use has_general_helpers;
+use sets_up_courses;
+use sets_up_notifications;
 
-class block_quickmail_schedulable_testcase extends advanced_testcase {
+final class schedulable_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/schedule_persistent_test.php
+++ b/tests/unit/schedule_persistent_test.php
@@ -21,13 +21,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\persistents\schedule;
+use has_general_helpers;
 
-class block_quickmail_schedule_persistent_testcase extends advanced_testcase {
+final class schedule_persistent_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/send_all_ready_messages_task_test.php
+++ b/tests/unit/send_all_ready_messages_task_test.php
@@ -21,14 +21,22 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\messenger\messenger;
 use block_quickmail\tasks\send_all_ready_messages_task;
+use has_general_helpers;
+use sends_emails;
+use sends_messages;
+use sets_up_courses;
+use submits_compose_message_form;
 
-class block_quickmail_send_all_ready_messages_task_testcase extends advanced_testcase {
+final class send_all_ready_messages_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/send_message_adhoc_task_test.php
+++ b/tests/unit/send_message_adhoc_task_test.php
@@ -21,15 +21,23 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\messenger\messenger;
 use block_quickmail\tasks\send_message_adhoc_task;
 use core\task\manager as task_manager;
+use has_general_helpers;
+use sends_emails;
+use sends_messages;
+use sets_up_courses;
+use submits_compose_message_form;
 
-class block_quickmail_send_message_adhoc_task_testcase extends advanced_testcase {
+final class send_message_adhoc_task_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/sent_repo_test.php
+++ b/tests/unit/sent_repo_test.php
@@ -21,15 +21,20 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
-use block_quickmail\repos\sent_repo;
+use advanced_testcase;
 use block_quickmail\persistents\message;
 use block_quickmail\repos\pagination\paginated;
+use block_quickmail\repos\sent_repo;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_sent_repo_testcase extends advanced_testcase {
+final class sent_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/signature_appender_test.php
+++ b/tests/unit/signature_appender_test.php
@@ -21,14 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\messenger\message\signature_appender;
 use block_quickmail\persistents\signature;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_signature_appender_testcase extends advanced_testcase {
+final class signature_appender_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/signature_persistent_test.php
+++ b/tests/unit/signature_persistent_test.php
@@ -21,13 +21,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\persistents\signature;
+use has_general_helpers;
 
-class block_quickmail_signature_persistent_testcase extends advanced_testcase {
+final class signature_persistent_test extends advanced_testcase {
 
     use has_general_helpers;
 

--- a/tests/unit/subject_prepender_test.php
+++ b/tests/unit/subject_prepender_test.php
@@ -21,13 +21,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\messenger\message\subject_prepender;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_subject_prepender_testcase extends advanced_testcase {
+final class subject_prepender_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses;

--- a/tests/unit/substitution_code_test.php
+++ b/tests/unit/substitution_code_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
 use block_quickmail\messenger\message\substitution_code;
+use creates_message_records;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_substitution_code_testcase extends advanced_testcase {
+final class substitution_code_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,

--- a/tests/unit/user_repo_test.php
+++ b/tests/unit/user_repo_test.php
@@ -21,13 +21,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_quickmail;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(dirname(__FILE__) . '/traits/unit_testcase_traits.php');
 
+use advanced_testcase;
+use assigns_mentors;
 use block_quickmail\repos\user_repo;
+use has_general_helpers;
+use sets_up_courses;
 
-class block_quickmail_user_repo_testcase extends advanced_testcase {
+final class user_repo_test extends advanced_testcase {
 
     use has_general_helpers,
         sets_up_courses,


### PR DESCRIPTION
PHPUnit test class filenames are not aligned with the classnames.
This is not compliant with Moodle coding standards, will cause issues with future version of PHPUnit and breaks moodle-tool_paratest